### PR TITLE
[BUGFIX] Always delete tmp handlers when called regardless of return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # [develop](https://github.com/adhearsion/has-guarded-handlers)
+  * Bugfix: Ensure temp handlers are executed only once.
+  * Improved documentation on how chained handlers execute via `throw :pass`, `throw :halt`, and not explicitly throwing.
 
 # [1.6.0](https://github.com/adhearsion/has-guarded-handlers/compare/v1.5.0...v1.6.0) - [2014-01-16](https://rubygems.org/gems/has-guarded-handlers/versions/1.6.0)
   * Feature: Add a broadcast mode to handler triggering, which ignores what happens in handlers (return value and exceptions) and unconditionally continues the handler chain.

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ a.register_handler_with_options(:event, {:tmp => true, :priority => 10}, :foo =>
 
 ### Handler chaining
 
-When multiple handlers match the event, the return value of each handler will determine if the handler chain continues. A truthy return value will cause the handler to swallow the event and halt the handler chain. A falsy return value will continue the chain.
+Each handler can control whether subsequent handlers should be executed by throwing `:pass` or `:halt`.
 
-It is possible to explicitly pass to the next handler by throwing `:pass` in your handler:
+To explicitly pass to the next handler, throw `:pass` in your handler:
 
 ```ruby
-a.register_handler(:event) { throw :pass }
+a.register_handler(:event) { do_stuff; throw :pass }
 a.register_handler(:event) { ... } # This will be executed
 
 a.trigger_handler :event, :foo
@@ -92,10 +92,28 @@ a.trigger_handler :event, :foo
 or indeed explicitly halt the handler chain by throwing `:halt` in the handler:
 
 ```ruby
-a.register_handler(:event) { throw :halt }
+a.register_handler(:event) { do_stuff; throw :halt }
 a.register_handler(:event) { ... } # This will not be executed
 
 a.trigger_handler :event, :foo
+```
+
+If nothing is thrown in the event handler, the handler chain will be halted by default, so subsequent handlers will not be executed.  
+
+```ruby
+a.register_handler(:event) { do_stuff; }
+a.register_handler(:event) { ... } # This will not be executed
+
+a.trigger_handler :event, :foo
+```
+
+By triggering the event in broadcast mode, the handler chain will continue by default.  
+
+```ruby
+a.register_handler(:event) { do_stuff; }
+a.register_handler(:event) { ... } # This will be executed
+
+a.trigger_handler :event, :foo, broadcast: true
 ```
 
 ### What are guards?

--- a/lib/has_guarded_handlers.rb
+++ b/lib/has_guarded_handlers.rb
@@ -104,7 +104,7 @@ module HasGuardedHandlers
             true unless broadcast
           end
         end
-        delete_handler_if(type) { |_, h, _| h.equal? handler } if tmp && val
+        delete_handler_if(type) { |_, h, _| h.equal? handler } if tmp && called
         val
       end
     end


### PR DESCRIPTION
I noticed a problem with #register_tmp_handler sometimes firing the same handler multiple times.  The issue had to do with the return value: if falsy, it would re-execute.  This also made it difficult to throw :pass, because it would then only remove the handler if subsequent handler was registered.

Also, presumably, the handler may have been deleted even if it was not actually called.

I simply changed the logic to delete the handler if it was marked as temporary and if it had been called, regardless of its return value.