### PR TITLE
Fixes handler chain documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ a.register_handler_with_options(:event, {:tmp => true, :priority => 10}, :foo =>
 
 ### Handler chaining
 
-When multiple handlers match the event, the return value of each handler will determine if the handler chain continues. A truthy return value will cause the handler to swallow the event and halt the handler chain. A falsy return value will continue the chain.
+Each handler can control whether subsequent handlers should be executed by throwing `:pass` or `:halt`.
 
-It is possible to explicitly pass to the next handler by throwing `:pass` in your handler:
+To explicitly pass to the next handler, throw `:pass` in your handler:
 
 ```ruby
-a.register_handler(:event) { throw :pass }
+a.register_handler(:event) { ...; throw :pass }
 a.register_handler(:event) { ... } # This will be executed
 
 a.trigger_handler :event, :foo
@@ -92,10 +92,28 @@ a.trigger_handler :event, :foo
 or indeed explicitly halt the handler chain by throwing `:halt` in the handler:
 
 ```ruby
-a.register_handler(:event) { throw :halt }
+a.register_handler(:event) { ...; throw :halt }
 a.register_handler(:event) { ... } # This will not be executed
 
 a.trigger_handler :event, :foo
+```
+
+If nothing is thrown in the event handler, the handler chain will be halted by default, so subsequent handlers will not be executed.  
+
+```ruby
+a.register_handler(:event) { ...; }
+a.register_handler(:event) { ... } # This will not be executed
+
+a.trigger_handler :event, :foo
+```
+
+By triggering the event in broadcast mode, the handler chain will continue by default.  
+
+```ruby
+a.register_handler(:event) { ...; }
+a.register_handler(:event) { ... } # This will be executed
+
+a.trigger_handler :event, :foo, broadcast: true
 ```
 
 ### What are guards?


### PR DESCRIPTION
There is a discrepancy between the way the handler chaining currently works (according to the specs and my own testing) and the documentation.  The documentation states that handler chaining is based on the return value of the handler, and this is currently not the case.  It is entirely based on whether broadcast mode is enabled and whether `throw :pass` or `throw :halt` are specified.  This PR updates the documentation accordingly.
