### PR TITLE
handler (storage) thread-safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - jruby-19mode
+  - 2.2.5
+  - jruby-1.7.25
+  - jruby-9.1.5.0
   - rbx-2.1.1
   - ruby-head
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/has-guarded-handlers)
+  * use ThreadSafe::Cache instead of Hash for storing handlers (improved concurrency)
 
 # [1.6.3](https://github.com/adhearsion/has-guarded-handlers/compare/v1.6.2...v1.6.3) - [2015-06-20](https://rubygems.org/gems/has-guarded-handlers/versions/1.6.3)
   * Bugfix: Clearing all handlers now works

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in has-guarded-handlers.gemspec
 gemspec
+
+group :development do
+  gem 'listen', '~> 3.0.8', :require => false
+end

--- a/has-guarded-handlers.gemspec
+++ b/has-guarded-handlers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'thread_safe', ["~> 0.3"]
+  s.add_dependency 'thread_safe', [">= 0.3.4"]
 
   s.add_development_dependency 'bundler', ["~> 1.0"]
   s.add_development_dependency 'rspec', ["~> 3.0"]

--- a/has-guarded-handlers.gemspec
+++ b/has-guarded-handlers.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency 'thread_safe', ["~> 0.3"]
+
   s.add_development_dependency 'bundler', ["~> 1.0"]
   s.add_development_dependency 'rspec', ["~> 3.0"]
   s.add_development_dependency 'yard', [">= 0.7.0"]


### PR DESCRIPTION
HGH's design is not thread-safe since most of the use-cases are actors themselves - thus protected from concurrent access. However, not all and esp. under JRuby (with non-GIL concurrency and likely due threaded fibers) some parts tend to break unexpectedly when a handler update is executed by 2 threads.

Here's a failure from the older stack which is still relevant today (with an updated Adhearsion 2.6 stack) :

```
ERROR Adhearsion::Initializer: <NoMethodError> undefined method `find' for nil:NilClass
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/has-guarded-handlers-1.6.0/lib/has_guarded_handlers.rb:149:in `guarded?'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/has-guarded-handlers-1.6.0/lib/has_guarded_handlers.rb:92:in `trigger_handler'
org/jruby/RubyKernel.java:1254:in `catch'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/has-guarded-handlers-1.6.0/lib/has_guarded_handlers.rb:91:in `trigger_handler'
org/jruby/RubyEnumerable.java:556:in `find'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/has-guarded-handlers-1.6.0/lib/has_guarded_handlers.rb:89:in `trigger_handler'
org/jruby/RubyKernel.java:1254:in `catch'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/has-guarded-handlers-1.6.0/lib/has_guarded_handlers.rb:88:in `trigger_handler'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/punchblock-2.5.3/lib/punchblock/translator/asterisk/call.rb:159:in `process_ami_event'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/punchblock-2.5.3/lib/punchblock/translator/asterisk.rb:209:in `ami_dispatch_to_or_create_call'
org/jruby/RubyHash.java:1357:in `each_pair'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/punchblock-2.5.3/lib/punchblock/translator/asterisk.rb:207:in `ami_dispatch_to_or_create_call'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/punchblock-2.5.3/lib/punchblock/translator/asterisk.rb:90:in `handle_ami_event'
org/jruby/RubyKernel.java:1932:in `public_send'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/celluloid-0.15.2/lib/celluloid/calls.rb:25:in `dispatch'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/celluloid-0.15.2/lib/celluloid/calls.rb:122:in `dispatch'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/celluloid-0.15.2/lib/celluloid/actor.rb:322:in `handle_message'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/celluloid-0.15.2/lib/celluloid/actor.rb:416:in `task'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/celluloid-0.15.2/lib/celluloid/tasks.rb:55:in `initialize'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/celluloid-0.15.2/lib/celluloid/tasks.rb:47:in `initialize'
/srv/phone/apptastic/shared/bundle/jruby/1.9/gems/celluloid-0.15.2/lib/celluloid/tasks/task_fiber.rb:13:in `create'
```

`@handlers ||= Hash.new { |h, k| h[k] = Hash.new { |h, k| h[k] = [] } }` the underlying issue is that when the same key is "missed" (under 2 threads) the default proc might execute twice ... with `TS::Cache` there's an atomic guarantee of `fetch_or_store` method - once set we're only retrieve the same value for the given key

p.s. `ThreadSafe::Cache` is part of the **concurrent-ruby** gem these days, if there's interest in getting the changes upstream it should be straightforward to migrate using `Concurrent::Hash` instead.
