### PR TITLE
recover from (concurrent) handler removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [develop](https://github.com/adhearsion/has-guarded-handlers)
   * use ThreadSafe::Cache instead of Hash for storing handlers (improved concurrency)
+  * Bugfix: recover from (concurrent) handler removal adhearsion/punchblock#234
 
 # [1.6.3](https://github.com/adhearsion/has-guarded-handlers/compare/v1.6.2...v1.6.3) - [2015-06-20](https://rubygems.org/gems/has-guarded-handlers/versions/1.6.3)
   * Bugfix: Clearing all handlers now works

--- a/lib/has_guarded_handlers.rb
+++ b/lib/has_guarded_handlers.rb
@@ -192,10 +192,10 @@ module HasGuardedHandlers
       # to make sure on re-try elements are not added
       # twice - attempt to copy _val_ to a new array:
       val = [].push *val
+      values.push *val # only here to ease testing
     rescue ConcurrencyError # re-read handler _val_
       return push_handler(handlers, key, values)
     end
-    values.push *val
   end
 
   def new_handler_id # :nodoc:

--- a/lib/has_guarded_handlers.rb
+++ b/lib/has_guarded_handlers.rb
@@ -135,7 +135,9 @@ module HasGuardedHandlers
       h = handler.find do |guards, handler, tmp|
         called = true
         val = catch(:pass) do
-          if guarded?(guards, event)
+          if guards.nil? # deleted while executing __method__
+            called = nil # very special case, nothing to call
+          elsif guarded?(guards, event)
             called = false
           else
             begin

--- a/lib/has_guarded_handlers.rb
+++ b/lib/has_guarded_handlers.rb
@@ -193,7 +193,7 @@ module HasGuardedHandlers
       # twice - attempt to copy _val_ to a new array:
       val = [].push *val
       values.push *val # only here to ease testing
-    rescue ConcurrencyError # re-read handler _val_
+    rescue ThreadError # ConcurrencyError on JRuby
       return push_handler(handlers, key, values)
     end
   end

--- a/lib/has_guarded_handlers.rb
+++ b/lib/has_guarded_handlers.rb
@@ -128,8 +128,8 @@ module HasGuardedHandlers
   # @option options [true, false] :broadcast Enables broadcast mode, where the return value or raising of handlers does not halt the handler chain. Defaults to false.
   # @option options [Proc] :exception_callback Allows handling exceptions when broadcast mode is available via a callback.
   def trigger_handler(type, event, options = {})
-    broadcast = options[:broadcast] || false
     return unless handler = handlers_of_type(type)
+    broadcast = options[:broadcast]
     called = false
     catch :halt do
       h = handler.find do |guards, handler, tmp|
@@ -154,7 +154,7 @@ module HasGuardedHandlers
         val
       end
     end
-    !!called
+    called
   end
 
   private

--- a/lib/has_guarded_handlers.rb
+++ b/lib/has_guarded_handlers.rb
@@ -165,19 +165,23 @@ module HasGuardedHandlers
 
   def delete_handler_if(type, &block) # :nodoc:
     guarded_handlers[type].each_pair do |priority, handlers|
-      handlers.delete_if(&block)
+      handlers.delete_if(&block) # concurrent array mod!?!
     end
   end
 
   def handlers_of_type(type) # :nodoc:
     return unless hash = guarded_handlers[type]
     values = []
-    hash.keys.sort.reverse.each do |key|
-      values += hash[key]
+    keys = hash.keys; keys.sort!; keys.reverse!
+    keys.each do |key|
+      val = hash[key]
+      values.push *val unless val.nil?
     end
     global_handlers = guarded_handlers[nil]
-    global_handlers.keys.sort.reverse.each do |key|
-      values += global_handlers[key]
+    keys = global_handlers.keys; keys.sort!; keys.reverse!
+    keys.each do |key|
+      val = global_handlers[key]
+      values.push *val unless val.nil?
     end
     values
   end

--- a/spec/has_guarded_handlers_spec.rb
+++ b/spec/has_guarded_handlers_spec.rb
@@ -80,6 +80,48 @@ describe HasGuardedHandlers do
       expect(subject.trigger_handler(:event, second_event)).to be true
       expect(subject.trigger_handler(:event, second_event)).to be false
     end
+
+    it 'recovers from concurrent modification as tmp handler is being removed' do
+      event = Object.new; def event.foo; :bar end
+      tmp_response = double '(tmp) Response'
+      expect(tmp_response).to receive(:call).exactly(1).times.with(event)
+      expect(response).to receive(:call).exactly(1).times.with(event)
+
+      require 'thread'; queue = Queue.new
+
+      subject.register_tmp_handler(:event, :foo => :bar) do |e|
+        tmp_response.call e; queue.pop
+      end
+
+      subject.register_handler(:event) do |e|
+         response.call e
+      end
+
+      Thread.new do
+        expect( subject.trigger_handler(:event, event) ).to be true
+      end
+
+      sleep 0.001 while queue.num_waiting == 0 # thread to end up in tmp handler
+
+      orig_method = subject.method(:push_handler)
+      subject.stub(:push_handler) do |handlers, key, values|
+        queue << :done; sleep 0.01 # let tmp handler finish-up
+        # we can not stub *val in any way thus we assume values.push
+        # is in the same begin - rescue block ...
+        def values.push(*args)
+          super.tap do
+            unless Thread.current[:__values_push_raised]
+              Thread.current[:__values_push_raised] = true
+              raise ConcurrencyError.new('stub-ed concurrent mod emulation')
+            end
+          end
+        end
+        orig_method.call(handlers, key, values)
+      end
+
+      expect( subject.trigger_handler(:event, event) ).to be true
+    end
+
   end
 
   it 'can unregister a handler after registration' do

--- a/spec/has_guarded_handlers_spec.rb
+++ b/spec/has_guarded_handlers_spec.rb
@@ -112,7 +112,8 @@ describe HasGuardedHandlers do
           super.tap do
             unless Thread.current[:__values_push_raised]
               Thread.current[:__values_push_raised] = true
-              raise ConcurrencyError.new('stub-ed concurrent mod emulation')
+              error = defined?(JRUBY_VERSION) ? ConcurrencyError : ThreadError
+              raise error.new('stub-ed concurrent mod emulation')
             end
           end
         end


### PR DESCRIPTION
... a follow up from https://github.com/adhearsion/has-guarded-handlers/pull/5

(under JRuby) for some specific use-cases more concurrency fixes are needed to run AHN safely.

there's 2 errors @cloudvox managed to run into (using JRuby 1.7) which both related to the same issue 
1. reported (by others) and explained at https://github.com/adhearsion/punchblock/issues/234#issuecomment-212342156
2. triggering a (tmp) handler while another `trigger_handler :ami` is happening concurrently, on JRuby :

```
ConcurrencyError: Detected invalid array contents due to unsynchronized modifications with concurrent users
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/has-guarded-handlers-4d4980673764/lib/has_guarded_handlers.rb:180:in `handlers_of_type'
    org/jruby/RubyArray.java:1617:in `each'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/has-guarded-handlers-4d4980673764/lib/has_guarded_handlers.rb:178:in `handlers_of_type'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/has-guarded-handlers-4d4980673764/lib/has_guarded_handlers.rb:131:in `trigger_handler'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/punchblock-42cbe4572035/lib/punchblock/translator/asterisk/call.rb:183:in `process_ami_event'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/punchblock-42cbe4572035/lib/punchblock/translator/asterisk.rb:230:in `ami_dispatch_to_or_create_call'
    org/jruby/RubyHash.java:1357:in `each_pair'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/punchblock-42cbe4572035/lib/punchblock/translator/asterisk.rb:228:in `ami_dispatch_to_or_create_call'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/punchblock-42cbe4572035/lib/punchblock/translator/asterisk.rb:112:in `handle_ami_event'
    org/jruby/RubyKernel.java:1932:in `public_send'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/celluloid-7af615463b10/lib/celluloid/calls.rb:25:in `dispatch'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/celluloid-7af615463b10/lib/celluloid/calls.rb:122:in `dispatch'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/celluloid-7af615463b10/lib/celluloid/actor.rb:322:in `handle_message'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/celluloid-7af615463b10/lib/celluloid/actor.rb:416:in `task'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/celluloid-7af615463b10/lib/celluloid/tasks.rb:55:in `initialize'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/celluloid-7af615463b10/lib/celluloid/tasks.rb:47:in `initialize'
    /srv/phone/apptastic/shared/bundle/jruby/1.9/bundler/gems/celluloid-7af615463b10/lib/celluloid/tasks/task_fiber.rb:13:in `create'
```

they both happen since [`PB::Translator::Asterisk::Call` instances are no longer actors](https://github.com/adhearsion/punchblock/commit/f939ecabed9f4922cf446cc22ff1d0e42c9632e5#diff-2d5dcf5f36f13b8f6dec5cebaf989d43L10) ... the changes proposed assure this case is covered correctly.

the later can be reproduced by running the following [minimal (only HGH) script](https://gist.github.com/kares/0c30b40e0e511177e2b22f44de350467#file-concurrency-issue-simplified2-rb) under JRuby ... simply `TIMES=1000 concurrency-issue-simplified2.rb` should do (make sure to `gem install concurrent-ruby`)

alternatives to solving the issue would be : 
1. introduce mutex locking (possibly only around `Call`'s handler triggering)
2. rewrite HGH to be fully thread-safe (there's still no guarantee a tmp handler won't fire twice)
3. avoid [tmp handler registration](https://github.com/cloudvox/punchblock/blob/dialogtech/support/2.7.5.dt2/lib/punchblock/translator/asterisk/call.rb#L295) in `Call` instances (there's also [one in `Component::Record`](https://github.com/cloudvox/punchblock/blob/dialogtech/support/2.7.5.dt2/lib/punchblock/translator/asterisk/component/record.rb#L25))
