### PR TITLE
use concurrent/map as a thread_safe replacement

### DIFF
--- a/has-guarded-handlers.gemspec
+++ b/has-guarded-handlers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'thread_safe', [">= 0.3.4"]
+  s.add_dependency 'concurrent-ruby', ["~> 1.0"]
 
   s.add_development_dependency 'bundler', ["~> 1.0"]
   s.add_development_dependency 'rspec', ["~> 3.0"]

--- a/lib/has_guarded_handlers.rb
+++ b/lib/has_guarded_handlers.rb
@@ -1,6 +1,6 @@
 require "has_guarded_handlers/version"
 require 'securerandom'
-require 'thread_safe'
+require 'concurrent/map'
 
 #
 # HasGuardedHandlers allows an object's API to provide flexible handler registration, storage and matching to arbitrary events.
@@ -234,8 +234,8 @@ module HasGuardedHandlers
   end
 
   def guarded_handlers
-    @handlers ||= ThreadSafe::Cache.new do |handlers, key|
-      handlers.fetch_or_store(key, ThreadSafe::Cache.new { |h, k| h.fetch_or_store(k, []) })
+    @handlers ||= Concurrent::Map.new do |handlers, key|
+      handlers.fetch_or_store(key, Concurrent::Map.new { |h, k| h.fetch_or_store(k, []) })
     end
   end
 


### PR DESCRIPTION
... works just fine with concurrent-ruby 1.0/1.1

also :green_heart: with CI updated: https://github.com/adhearsion/has-guarded-handlers/pull/8