### PR TITLE
register/unregister thread safety

### DIFF
--- a/has-guarded-handlers.gemspec
+++ b/has-guarded-handlers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'thread_safe', [">= 0.3.4"]
+  s.add_dependency 'concurrent-ruby', ["~> 1.0"]
 
   s.add_development_dependency 'bundler', ["~> 1.0"]
   s.add_development_dependency 'rspec', ["~> 3.0"]

--- a/lib/has_guarded_handlers.rb
+++ b/lib/has_guarded_handlers.rb
@@ -94,10 +94,8 @@ module HasGuardedHandlers
   # @return [String] handler ID for later manipulation
   def register_handler_with_options(type = nil, options = {}, *guards, &handler)
     check_guards guards
-    options[:priority] ||= 0
-    new_handler_id.tap do |handler_id|
-      guarded_handlers[type][options[:priority]] << [guards, handler, options[:tmp], handler_id]
-    end
+    priority = (options[:priority] ||= 0)
+    do_register_handler(type, new_handler_id, priority, guards, handler, options[:tmp])
   end
 
   # Unregister a handler by ID
@@ -163,10 +161,30 @@ module HasGuardedHandlers
     handler.call event
   end
 
-  def delete_handler_if(type, &block) # :nodoc:
-    guarded_handlers[type].each_pair do |priority, handlers|
-      handlers.delete_if(&block)
+  def do_register_handler(type, handler_id, priority, guards, handler, tmp)
+    handlers_map = guarded_handlers[type]
+    tuples = handlers_map[priority]
+    new_tuples = (tuples.dup << [guards, handler, tmp, handler_id])
+    unless handlers_map.replace_pair(priority, tuples, new_tuples)
+      # try again, some one concurrently registered another handler
+      do_register_handler(type, handler_id, priority, guards, handler, tmp)
     end
+    handler_id
+  end
+
+  def delete_handler_if(type, &block) # :nodoc:
+    handlers_map = guarded_handlers[type]
+    ret = handlers_map.each_pair do |priority, tuples|
+      new_tuples = tuples.dup
+      cur_size = new_tuples.size
+      new_tuples.delete_if(&block)
+      if cur_size != new_tuples.size
+        break unless handlers_map.replace_pair(priority, tuples, new_tuples)
+      end
+    end
+    # if broke out of loop, try again (no changes made)
+    return delete_handler_if(type, &block) if ret.nil?
+    true
   end
 
   def handlers_of_type(type) # :nodoc:

--- a/lib/has_guarded_handlers.rb
+++ b/lib/has_guarded_handlers.rb
@@ -1,6 +1,6 @@
 require "has_guarded_handlers/version"
 require 'securerandom'
-require 'thread_safe'
+require 'concurrent/map'
 
 #
 # HasGuardedHandlers allows an object's API to provide flexible handler registration, storage and matching to arbitrary events.
@@ -234,8 +234,8 @@ module HasGuardedHandlers
   end
 
   def guarded_handlers
-    @handlers ||= ThreadSafe::Cache.new do |handlers, key|
-      handlers.fetch_or_store(key, ThreadSafe::Cache.new { |h, k| h.fetch_or_store(k, []) })
+    @handlers ||= Concurrent::Map.new do |handlers, key|
+      handlers.fetch_or_store(key, Concurrent::Map.new { |h, k| h.fetch_or_store(k, []) })
     end
   end
 

--- a/spec/has_guarded_handlers_spec.rb
+++ b/spec/has_guarded_handlers_spec.rb
@@ -82,6 +82,55 @@ describe HasGuardedHandlers do
     end
   end
 
+  it 'allows handlers of same type to be added/removed concurrently' do
+    %w( concurrent/array concurrent/atomic/atomic_fixnum).each { |p| require p }
+    Thread.abort_on_exception = true
+
+    Event = Class.new do
+      attr_reader :track, :count
+      def initialize(c = 0)
+        @count = Concurrent::AtomicFixnum.new(c)
+        @track = Concurrent::AtomicFixnum.new
+      end
+      def inc_track; @track.increment > 0 end
+      def cmp_count(i); @count.increment >= i end
+      def dec_count; @count.decrement end
+    end
+
+    event = Event.new
+
+    subject.register_handler :ami, [{ [:inc_track] => true }] do |e|
+      sleep(0)
+    end
+    expect( subject.send(:guarded_handlers)[:ami][0].size ).to eql 1
+
+    handler_id = subject.register_handler(:ami, [ [:nil?] ]) { |_| }
+    expect( subject.send(:guarded_handlers)[:ami][0].size ).to eql 2
+
+    tmp_handler_count = 3000; threads = Concurrent::Array.new
+    tmp_handler_count.times do |i| # enough to reproduce concurrent regiter/unregister
+      threads << Thread.new do
+        h_id = subject.register_tmp_handler(:ami, [{ [:cmp_count, i] => true }]) do |e|
+          e.dec_count
+        end
+        threads << Thread.new do
+          subject.unregister_handler(:ami, h_id)
+        end
+        subject.trigger_handler(:ami, event)
+      end
+    end
+    sleep(1.0)
+    threads.each(&:join)
+
+    expect( subject.trigger_handler(:ami, event) ).to be true
+    expect( subject.send(:guarded_handlers)[:ami][0].size ).to eql 2
+
+    expect( event.track.value ).to eql tmp_handler_count + 1
+
+    subject.unregister_handler(:ami, handler_id)
+    expect( subject.send(:guarded_handlers)[:ami][0].size ).to eql 1
+  end
+
   it 'can unregister a handler after registration' do
     expect(response).to receive(:call).once.with(event)
     subject.register_handler(:event) { |e| response.call e }


### PR DESCRIPTION
kept the (plain) array storage,
however we defensively dup and make changes to handler storage
than use map's atomic operations to set the updated instance

resolves adhearsion/adhearsion#634

for simplicity, this PR incorporates: https://github.com/adhearsion/has-guarded-handlers/pull/7